### PR TITLE
Suggested changes to init

### DIFF
--- a/bin/imp-init.js
+++ b/bin/imp-init.js
@@ -9,6 +9,12 @@ var config = new ImpConfig();
 
 var imp;
 
+program
+  .option("--overwrite", "Will overwrite configuration if configuration already exists (typically used for switching between accounts)")
+  .option("--keepCode", "Device and agent code will not be overwritten with latest model code")
+  .option("--keepDeviceCode", "Device code will not be overwritten with latest model device code")
+  .option("--keepAgentCode", "Agent code will not be overwritten with latest model agent code")
+
 program.parse(process.argv);
 
 function apiKeyPrompt(apiKey, next) {
@@ -95,8 +101,16 @@ function modelPrompt(next) {
                 return;
               }
 
-              config.setLocal("modelName", val);
-              next();
+              imp.createModel(val, function(err, data) {
+                if (err) {
+                  console.log("ERROR: Could not create model");
+                  return;
+                }
+
+                config.setLocal("modelName", data.model.name);
+                config.setLocal("modelId", data.model.id);
+                next();
+              });
               return;
             });
           }
@@ -139,19 +153,29 @@ function fileNamePrompt(next) {
   var modelName = config.getLocal("modelName");
 
   var baseFileName = modelName.split(" ").join("_").toLowerCase();
-  var defaultDeviceFileName = baseFileName + ".device.nut";
-  var defaultAgentFileName = baseFileName + ".agent.nut";
 
-  prompt("Device code file (" + defaultDeviceFileName + "): ", function(deviceFile) {
-    if (!deviceFile) deviceFile = defaultDeviceFileName;
-    config.setLocal("deviceFile", deviceFile);
-    prompt("Agent code file (" + defaultAgentFileName + "): ", function(agentFile) {
-      if (!agentFile) agentFile = defaultAgentFileName;
-      config.setLocal("agentFile", agentFile);
+  var defaultDeviceFileName = config.getLocal("deviceFile") || (baseFileName + ".device.nut");
+  var defaultAgentFileName = config.getLocal("agentFile") || (baseFileName + ".agent.nut");
 
-      next();
-    });
+  prompt.multi([
+    {
+      label: "Device code file ("+defaultDeviceFileName+")",
+      key: "deviceFile",
+    },
+    {
+      label: " ",
+      key: "workaround"
+    },
+    {
+      label: "Agent code file ("+defaultAgentFileName+")",
+      key: "agentFile",
+    }
+  ], function(data){
+    config.setLocal("deviceFile", data.deviceFile || defaultDeviceFileName);
+    config.setLocal("deviceFile", data.agentFile || defaultAgentFileName);
+    next();
   });
+
 }
 
 function finalize() {
@@ -170,7 +194,17 @@ function finalize() {
         return;
       }
 
-      if (data.revisions.length > 0) {
+      if (data.revisions.length == 0){
+        config.saveLocalConfig(function(err) {
+          if (err) {
+            console.log("ERROR: " + err);
+            return;
+          }
+
+          console.log("Success! To add devices run:");
+          console.log("   imp devices -a <deviceId>");
+        });
+      } else if (data.revisions.length > 0) {
         imp.getModelRevision(modelId, data.revisions[0].version, function(err, data) {
           if (err) {
             console.log("ERROR: Could not fetch code revisions");
@@ -180,8 +214,16 @@ function finalize() {
           deviceCode = data.revision.device_code;
           agentCode = data.revision.agent_code;
 
-         fs.writeFile(deviceFile, deviceCode);
-         fs.writeFile(agentFile, agentCode);
+          if ("keepCode" in program || ("keepDeviceCode" in program && "keepAgentCode" in program)){
+            //Don't overwrite any saved code
+          } else if ("keepDeviceCode" in program){ //only overwrite the agent code
+            fs.writeFile(agentFile, agentCode);
+          } else if ("keepAgentCode" in program){ //only overwrite the device code
+            fs.writeFile(deviceFile, deviceCode);
+          } else {
+            fs.writeFile(deviceFile, deviceCode);
+            fs.writeFile(agentFile, agentCode);
+          }
 
           config.saveLocalConfig(function(err) {
             if (err) {
@@ -223,7 +265,14 @@ function finalize() {
 config.init(null, function() {
   // Make sure this folder doesn't already have a config file
   if (this.getLocalConfig()) {
-    console.log("ERROR: .impconfig already exists.");
+    if (!("overwriteConfig" in program)){
+      console.log("ERROR: .impconfig already exists. Specify option '--overwriteConfig' to set new configuration.");
+      return;
+    }
+  }
+
+  if (("keepCode" in program && "keepDeviceCode" in program) || ("keepCode" in program && "keepAgentCode" in program)){
+    console.log("ERROR: Option '--keepCode' cannot be combined with either '--keepDeviceCode' or '--keepAgentCode'");
     return;
   }
 


### PR DESCRIPTION
- [SUGGEST] Added option '--overwrite' to overwrite changes to local
  .impconfig
- [SUGGEST] Added option '--keepCode' to ensure that device/agent code
  doesn't get overwritten with latest model code
- [SUGGEST] Added option '--keepDeviceCode' to ensure that device code
  doesn't get overwritten with latest model code
- [SUGGEST] Added option '--keepAgentCode' to ensure that device code
  doesn't get overwritten with latest model code
- [SUGGEST] After prompt "Create a new model" if model doesn't exist,
  added code to actually create the model through the imp api.
- [SUGGEST] In case the local configuration already exists, and is being
  overwritten, changes defaultDevice/AgentFileName is either the locally
  saved name or the default name
- [BUGFIX] For Windows machines (or, at least my development machine),
  cli-prompt has an issue (I've documented at
  https://github.com/carlos8f/node-cli-prompt/issues/3) that makes chained
  prompts behave improperly. Added workaround with prompt.multi()
