### PR TITLE
Update cli-prompt dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/beardedinventor/imp-cli",
   "dependencies": {
-    "cli-prompt": "^0.4.1",
+    "cli-prompt": "^0.4.2",
     "cli-table": "^0.3.1",
     "colors": "^1.1.0",
     "commander": "^2.8.1",


### PR DESCRIPTION
Updated version of cli-prompt to 0.4.2 in dependencies -- this version includes support for windows prompts.
